### PR TITLE
Making JSON input optional, defaulting to simple plain text rsyslog messages

### DIFF
--- a/hnormalise.cabal
+++ b/hnormalise.cabal
@@ -26,6 +26,7 @@ library
                      , HNormalise.Lmod.Parser
                      , HNormalise.Rsyslog.Internal
                      , HNormalise.Rsyslog.Json
+                     , HNormalise.Rsyslog.Parser
                      , HNormalise.Torque.Internal
                      , HNormalise.Torque.Json
                      , HNormalise.Torque.Parser

--- a/src/HNormalise.hs
+++ b/src/HNormalise.hs
@@ -55,8 +55,7 @@ getJsonKey (PR_T _) = "torque"
 --------------------------------------------------------------------------------
 parseMessage :: Parser ParseResult
 parseMessage =
-        (parseHuppel >>= (\v -> return $ PR_H v))
-    <|> (parseLmodLoad >>= (\v -> return $ PR_L v))
+        (parseLmodLoad >>= (\v -> return $ PR_L v))
     <|> (parseTorqueExit >>= (\v -> return $ PR_T v))
 
 --------------------------------------------------------------------------------
@@ -74,5 +73,6 @@ normaliseRsyslog :: Rsyslog               -- ^ Incoming rsyslog information
                  -> Maybe SBS.ByteString  -- ^ IF the conversion succeeded the JSON encoded rsyslog message to forward
 normaliseRsyslog rsyslog = do
     cm <- convertMessage $ msg rsyslog
-    let nrsyslog = NRsyslog { rsyslog = rsyslog, normalised = cm, jsonkey = GetJsonKey getJsonKey }
-    return $ BS.toStrict $ Aeson.encode $ nrsyslog
+    return $ BS.toStrict
+           $ Aeson.encode
+           $ NRsyslog { rsyslog = rsyslog, normalised = cm, jsonkey = GetJsonKey getJsonKey }

--- a/src/HNormalise/Lmod/Internal.hs
+++ b/src/HNormalise/Lmod/Internal.hs
@@ -10,27 +10,20 @@ import           Data.Text
 import           GHC.Generics (Generic)
 --------------------------------------------------------------------------------
 
--- username=vsc41480,
---cluster=delcatty,
---jobid=3230905.master15.delcatty.gent.vsc,
---userload=yes,
---module=GSL\/2.3-intel-2016b,
---fn=\/apps\/gent\/CO7\/sandybridge\/modules\/all\/GSL\/2.3-intel-2016b
-
 data LmodModule = LmodModule
-    { name    :: Text
-    , version :: Text
+    { name    :: !Text
+    , version :: !Text
     } deriving (Show, Eq, Generic)
 
 data LmodInfo = LmodInfo
-    { username :: Text
-    , cluster  :: Text
-    , jobid    :: Text
+    { username :: !Text
+    , cluster  :: !Text
+    , jobid    :: !Text
     } deriving (Show, Eq, Generic)
 
 data LmodLoad = LmodLoad
-    { info     :: LmodInfo
-    , userload :: Bool
-    , modul    :: LmodModule
-    , filename :: Text
+    { info     :: !LmodInfo
+    , userload :: !Bool
+    , modul    :: !LmodModule
+    , filename :: !Text
     } deriving (Show, Eq, Generic)

--- a/src/HNormalise/Rsyslog/Json.hs
+++ b/src/HNormalise/Rsyslog/Json.hs
@@ -43,7 +43,7 @@ instance ToJSON Rsyslog where
 instance (ToJSON a) => ToJSON (NormalisedRsyslog a) where
     toEncoding (NRsyslog r j (GetJsonKey f)) =
         pairs
-        (  "message" .= msg r
-        <> "syslog_abspri" .= syslogseverity r
-        <> (f j) .= toJSON j
-        )
+            (  "message" .= msg r
+            <> "syslog_abspri" .= syslogseverity r
+            <> (f j) .= j
+            )

--- a/src/HNormalise/Rsyslog/Parser.hs
+++ b/src/HNormalise/Rsyslog/Parser.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+module HNormalise.Rsyslog.Parser where
+
+
+--------------------------------------------------------------------------------
+import           Data.Attoparsec.ByteString.Char8
+import qualified Data.Text                         as T
+import qualified Data.Text.Encoding                as TE
+--------------------------------------------------------------------------------
+import           HNormalise.Rsyslog.Internal
+
+--------------------------------------------------------------------------------
+rsyslogLogstashTemplate = "<%PRI%>1 %timegenerated:::date-rfc3339% %HOSTNAME% %syslogtag% - %APP-NAME%: %msg:::drop-last-lf%\n"
+
+--------------------------------------------------------------------------------
+parseRsyslogLogstashString :: Parser Rsyslog
+parseRsyslogLogstashString = do
+    pri <- char '<' *> takeTill (== '>')
+    char '>' *> decimal
+    timegenerated <- skipSpace *> takeTill isSpace
+    hostname <- skipSpace *> takeTill isSpace
+    syslogtag <- skipSpace *> takeTill isSpace  -- FIXME: this might be incorrect
+    skipSpace *> char '-'
+    appname <- skipSpace *> takeTill (== ':')
+    msg <- char ':' *> skipSpace *> takeByteString
+    return Rsyslog
+        { msg              = TE.decodeUtf8 msg
+        , timereported     = T.empty
+        , hostname         = TE.decodeUtf8 hostname
+        , syslogtag        = TE.decodeUtf8 syslogtag
+        , inputname        = T.empty
+        , fromhost         = T.empty
+        , fromhost_ip      = T.empty
+        , pri              = TE.decodeUtf8 pri
+        , syslogfacility   = T.empty
+        , syslogseverity   = T.empty
+        , timegenerated    = TE.decodeUtf8 timegenerated
+        , programname      = T.empty
+        , protocol_version = T.empty
+        , app_name         = TE.decodeUtf8 appname
+        , procid           = T.empty
+    }

--- a/src/HNormalise/Torque/Parser.hs
+++ b/src/HNormalise/Torque/Parser.hs
@@ -54,10 +54,10 @@ parseTorqueSeconds = do
 parseTorqueMemory :: Parser Integer
 parseTorqueMemory = do
     v <- decimal
-    unit <- string "b"
-        <|> string "kb"
-        <|> string "mb"
-        <|> string "gb"
+    unit <- asciiCI "b"
+        <|> asciiCI "kb"
+        <|> asciiCI "mb"
+        <|> asciiCI "gb"
     return $ case unit of
         "b"  -> v
         "kb" -> v * 1024
@@ -99,21 +99,21 @@ parseTorqueResourceNodeList = do
 parseTorqueResourceRequest :: Parser TorqueResourceRequest
 parseTorqueResourceRequest = do
     permute $ TorqueResourceRequest
-        <$$> whitespace *> string "Resource_List.nodes=" *> parseTorqueResourceNodeList
-        <||> whitespace *> string "Resource_List.vmem=" *> parseTorqueMemory
-        <||> whitespace *> kvNumParser "Resource_List.nodect"
-        <||> whitespace *> string "Resource_List.neednodes=" *> parseTorqueResourceNodeList
-        <||> maybeOption (whitespace *> kvNumParser "Resource_List.nice")
-        <||> whitespace *> string "Resource_List.walltime=" *> parseTorqueWalltime
+        <$$> skipSpace *> string "Resource_List.nodes=" *> parseTorqueResourceNodeList
+        <||> skipSpace *> string "Resource_List.vmem=" *> parseTorqueMemory
+        <||> skipSpace *> kvNumParser "Resource_List.nodect"
+        <||> skipSpace *> string "Resource_List.neednodes=" *> parseTorqueResourceNodeList
+        <||> maybeOption (skipSpace *> kvNumParser "Resource_List.nice")
+        <||> skipSpace *> string "Resource_List.walltime=" *> parseTorqueWalltime
 
 --------------------------------------------------------------------------------
 parseTorqueResourceUsage :: Parser TorqueResourceUsage
 parseTorqueResourceUsage = do
-    cput <- whitespace *> kvNumParser "resources_used.cput"
-    energy <- whitespace *> kvNumParser "resources_used.energy_used"
-    mem <- whitespace *> string "resources_used.mem=" *> parseTorqueMemory
-    vmem <- whitespace *> string "resources_used.vmem=" *> parseTorqueMemory
-    walltime <- whitespace *> string "resources_used.walltime=" *> parseTorqueWalltime
+    cput <- skipSpace *> kvNumParser "resources_used.cput"
+    energy <- skipSpace *> kvNumParser "resources_used.energy_used"
+    mem <- skipSpace *> string "resources_used.mem=" *> parseTorqueMemory
+    vmem <- skipSpace *> string "resources_used.vmem=" *> parseTorqueMemory
+    walltime <- skipSpace *> string "resources_used.walltime=" *> parseTorqueWalltime
     return $ TorqueResourceUsage
         { cputime = cput
         , energy = energy
@@ -143,26 +143,26 @@ parseTorqueHostList = flip sepBy (char '+') $ do
 --------------------------------------------------------------------------------
 parseTorqueExit :: Parser TorqueJobExit
 parseTorqueExit = do
-    _ <- manyTill anyChar (lookAhead ";E;") *> string ";E;"   -- drop the prefix
+    takeTill (== ';') *> string ";E;"   -- drop the prefix
     name <- parseTorqueJobName
     user <- kvTextParser "user"
-    group <- whitespace *> kvTextParser "group"
-    jobname <- whitespace *> kvTextParser "jobname"
-    queue <- whitespace *> kvTextParser "queue"
-    start_count <- maybeOption $ whitespace *> kvNumParser "start_count"
-    ctime <- whitespace *> kvNumParser "ctime"
-    qtime <- whitespace *> kvNumParser "qtime"
-    etime <- whitespace *> kvNumParser "etime"
-    start <- whitespace *> kvNumParser "start"
-    owner <- whitespace *> kvTextParser "owner"
-    exec_host <- whitespace *> parseTorqueHostList
+    group <- skipSpace *> kvTextParser "group"
+    jobname <- skipSpace *> kvTextParser "jobname"
+    queue <- skipSpace *> kvTextParser "queue"
+    start_count <- maybeOption $ skipSpace *> kvNumParser "start_count"
+    ctime <- skipSpace *> kvNumParser "ctime"
+    qtime <- skipSpace *> kvNumParser "qtime"
+    etime <- skipSpace *> kvNumParser "etime"
+    start <- skipSpace *> kvNumParser "start"
+    owner <- skipSpace *> kvTextParser "owner"
+    exec_host <- skipSpace *> parseTorqueHostList
     request <- parseTorqueResourceRequest
-    session <- whitespace *> kvNumParser "session"
-    total_execution_slots <- whitespace *> kvNumParser "total_execution_slots"
-    unique_node_count <- whitespace *> kvNumParser "unique_node_count"
-    end <- whitespace *> kvNumParser "end"
-    exit_status <- whitespace *> kvNumParser "Exit_status"
-    usage <- whitespace *> parseTorqueResourceUsage
+    session <- skipSpace *> kvNumParser "session"
+    total_execution_slots <- skipSpace *> kvNumParser "total_execution_slots"
+    unique_node_count <- skipSpace *> kvNumParser "unique_node_count"
+    end <- skipSpace *> kvNumParser "end"
+    exit_status <- skipSpace *> kvNumParser "Exit_status"
+    usage <- skipSpace *> parseTorqueResourceUsage
 
     return $ TorqueJobExit
         { name = name


### PR DESCRIPTION
- add an option turning the current JSON based input parsing off
- add parser for a plain text input message using a simple encoding scheme
- parse from ByteString, avoiding building a complete Rsyslog JSON object
- speedup from 6.5K to 7.3K messages/s 